### PR TITLE
ability to recreate containers for existing users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "aiodocker>=0.24.0",
+    "aiofiles>=24.1.0",
     "fastapi>=0.116.1",
     "fastmcp>=2.12.2",
     "nanoid>=2.0.0",

--- a/src/hosted_link_proxy.py
+++ b/src/hosted_link_proxy.py
@@ -64,4 +64,4 @@ class HostedLinkProxyMiddleware(BaseHTTPMiddleware):
             return await ServerManager.get_unassigned_server_host()
 
         # hosted link
-        return ServerManager.full_hostname(self._get_hostname_from_link(path))
+        return ServerManager.external_hostname(self._get_hostname_from_link(path))

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ mcp_apps = get_mcp_apps()
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     setup_logging(settings.LOG_LEVEL)
-    await ServerManager.backfill_container_pool()
+    await ServerManager.reload_container()
 
     async with AsyncExitStack() as stack:
         for mcp_app in mcp_apps.values():

--- a/src/server_manager.py
+++ b/src/server_manager.py
@@ -1,11 +1,14 @@
 import asyncio
 import random
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any
 
+import aiofiles
 from aiodocker import Docker
 from aiodocker.containers import DockerContainer
 from nanoid import generate
+from pydantic import BaseModel
 
 from src.auth import AuthUser
 from src.logs import logger
@@ -13,6 +16,48 @@ from src.settings import settings
 
 UNASSIGNED_USER_NAME = "UNASSIGNED"
 FRIENDLY_CHARS: str = "23456789abcdefghijkmnpqrstuvwxyz"
+
+
+class ContainerMetadata(BaseModel):
+    user: AuthUser
+
+
+class Container:
+    """
+    Wrapper around a DockerContainer.
+    Container names are [USER_NAME]-[HOSTNAME] or UNASSIGNED-[HOSTNAME]
+    """
+
+    def __init__(self, container: DockerContainer):
+        self.container = container
+
+    @property
+    def id(self) -> str:
+        return self.container.id[:12]
+
+    @property
+    def hostname(self) -> str:
+        container_name = self.container._container["Names"][0].strip("/")  # type: ignore[reportUnknownMemberType]
+        return container_name.split("-")[-1]
+
+    @property
+    def mount_dir(self) -> Path:
+        return self.mount_dir_for_hostname(self.hostname)
+
+    @classmethod
+    def mount_dir_for_hostname(cls, hostname: str) -> Path:
+        path = settings.server_mount_parent_dir / hostname
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    @property
+    def metadata_file(self) -> Path:
+        return self.metadata_file_for_hostname(self.hostname)
+
+    @classmethod
+    def metadata_file_for_hostname(cls, hostname: str) -> Path:
+        return cls.mount_dir_for_hostname(hostname) / "metadata.json"
 
 
 class ServerManager:
@@ -43,27 +88,41 @@ class ServerManager:
         async with docker_client() as docker:
             if not await cls._user_has_container(user, docker=docker):
                 await cls._assign_container(user, docker=docker)
-                await cls.backfill_container_pool(docker=docker)
-        return cls.full_hostname(user.user_name)
+                await cls.backfill_container_pool(num=1, docker=docker)
+        return cls.external_hostname(user.user_name)
 
     @classmethod
     async def get_unassigned_server_host(cls) -> str:
         container = await cls._get_random_unassigned_container()
-        container_name = cls._container_name(container)
-        hostname = container_name.split("-")[-1]
-        return cls.full_hostname(hostname)
+        return cls.external_hostname(container.hostname)
 
     @classmethod
-    def full_hostname(cls, hostname: str) -> str:
+    def external_hostname(cls, hostname: str) -> str:
+        """Hostname of the container that can be reached from outside of Docker network."""
         return f"{hostname}{settings.DOCKER_DOMAIN}"
 
     @classmethod
-    async def backfill_container_pool(cls, *, docker: Docker | None = None):
+    async def reload_container(cls):
+        # List all directories in the server mount directory
+        mount_dirs = [item for item in settings.server_mount_parent_dir.iterdir() if item.is_dir()]
+        async with docker_client() as docker:
+            await asyncio.gather(
+                *[cls._create_container(mount_dir=item, docker=docker) for item in mount_dirs],
+                cls.backfill_container_pool(
+                    num=settings.MIN_CONTAINER_POOL_SIZE - len(mount_dirs), docker=docker
+                ),
+            )
+
+        logger.info(f"Reloaded {len(mount_dirs)} containers")
+
+    @classmethod
+    async def backfill_container_pool(cls, *, num: int | None = None, docker: Docker | None = None):
         async with docker_client(docker) as _docker:
-            containers = await cls._get_containers(prefix=UNASSIGNED_USER_NAME, docker=_docker)
-            num = settings.MIN_CONTAINER_POOL_SIZE - len(containers)
+            if num is None:
+                containers = await cls._get_containers(prefix=UNASSIGNED_USER_NAME, docker=_docker)
+                num = settings.MIN_CONTAINER_POOL_SIZE - len(containers)
             logger.info(f"Backfill server pool with {num} servers")
-            await asyncio.gather(*[cls._create_server(docker=_docker) for _ in range(num)])
+            await asyncio.gather(*[cls._create_container(docker=_docker) for _ in range(num)])
 
     @classmethod
     async def _user_has_container(cls, user: AuthUser, *, docker: Docker | None = None) -> bool:
@@ -71,22 +130,47 @@ class ServerManager:
         return len(containers) != 0
 
     @classmethod
+    async def _get_containers(cls, *, prefix: str, docker: Docker | None = None):
+        async with docker_client(docker) as docker:
+            containers = await docker.containers.list(  # type: ignore[reportUnknownMemberType]
+                filters={"ancestor": [settings.SERVER_IMAGE], "name": [prefix]}
+            )
+        return [Container(container) for container in containers]
+
+    @classmethod
     async def _get_random_unassigned_container(cls, docker: Docker | None = None):
         containers = await cls._get_containers(prefix=UNASSIGNED_USER_NAME, docker=docker)
         if not containers:
             raise ValueError("No unassigned containers found")
         container = random.choice(containers)
-        logger.info(f"Randomly selected unassigned container {container.id[:12]}")
+        logger.info(f"Randomly selected unassigned container {container.id}")
         return container
 
     @classmethod
-    async def _create_server(cls, *, docker: Docker | None = None):
-        # TODO: ensure the hostname is unique
-        hostname = generate(FRIENDLY_CHARS, 6)
+    async def _create_container(
+        cls, *, mount_dir: Path | None = None, docker: Docker | None = None
+    ):
+        """Create a fresh container for UNASSIGNED user or load from a mount_dir for an existing user."""
+        if mount_dir is None:
+            # TODO: ensure the hostname is unique
+            hostname = generate(FRIENDLY_CHARS, 6)
+            user_hostname = None
+        else:
+            hostname = mount_dir.stem
+            metadata = await cls._read_metadata(hostname)
+            user_hostname = metadata.user.user_name if metadata else None
 
-        # TODO: reuse the data dir when the container is recreated
-        src_data_dir = str(settings.server_mount_dir(hostname))
+        container_name = f"{user_hostname or UNASSIGNED_USER_NAME}-{hostname}"
+        containers = await cls._get_containers(prefix=container_name, docker=docker)
+        if containers:
+            logger.info(f"Container {container_name} already exists")
+            return hostname
+
+        src_data_dir = str(Container.mount_dir_for_hostname(hostname))
         dst_data_dir = "/app/data"
+        network_aliases = [cls.external_hostname(hostname)]
+        if user_hostname:
+            network_aliases.append(cls.external_hostname(user_hostname))
 
         config: dict[str, Any] = {
             "Image": settings.SERVER_IMAGE,
@@ -103,13 +187,13 @@ class ServerManager:
             ],
             "HostConfig": {"Binds": [f"{src_data_dir}:{dst_data_dir}:rw"]},
             "NetworkingConfig": {
-                "EndpointsConfig": {cls._network_name(): {"Aliases": [cls.full_hostname(hostname)]}}
+                "EndpointsConfig": {cls._network_name(): {"Aliases": network_aliases}}
             },
         }
 
         async with docker_client(docker) as docker:
             container = await docker.containers.run(  # type: ignore[reportUnknownMemberType]
-                config, name=f"{UNASSIGNED_USER_NAME}-{hostname}"
+                config, name=container_name
             )
             logger.info(f"Created server hostname: {hostname}, id: {container.id[:12]}")
         return hostname
@@ -119,10 +203,10 @@ class ServerManager:
         async with docker_client(docker) as docker:
             # rename the container to [AuthUser.user_name]-[HOSTNAME]
             container = await cls._get_random_unassigned_container(docker)
-            unassigned_container_name: str = cls._container_name(container)
-            hostname = unassigned_container_name.removeprefix(f"{UNASSIGNED_USER_NAME}-")
-            assigned_container_name = f"{user.user_name}-{hostname}"
-            await container.rename(assigned_container_name)  # type: ignore[reportUnknownMemberType]
+            assigned_container_name = f"{user.user_name}-{container.hostname}"
+            await container.container.rename(assigned_container_name)  # type: ignore[reportUnknownMemberType]
+
+            await cls._write_metadata(container, user)
 
             # add HOSTNAME and USER_HOSTNAME (AuthUser.user_name) to the container network aliases
             network = await docker.networks.get(cls._network_name())
@@ -130,7 +214,10 @@ class ServerManager:
             await network.connect({  # type: ignore[reportUnknownMemberType]
                 "Container": container.id,
                 "EndpointConfig": {
-                    "Aliases": [cls.full_hostname(hostname), cls.full_hostname(user.user_name)]
+                    "Aliases": [
+                        cls.external_hostname(container.hostname),
+                        cls.external_hostname(user.user_name),
+                    ]
                 },
             })
             logger.info(f"Assigned container {container.id} to {user.user_name}")
@@ -138,17 +225,20 @@ class ServerManager:
         return user.user_name
 
     @classmethod
-    async def _get_containers(cls, *, prefix: str, docker: Docker | None = None):
-        """Container names are [USER_NAME]-[HOSTNAME] or UNASSIGNED-[HOSTNAME]"""
-        async with docker_client(docker) as docker:
-            containers = await docker.containers.list(  # type: ignore[reportUnknownMemberType]
-                filters={"ancestor": [settings.SERVER_IMAGE], "name": [prefix]}
-            )
-        return containers
+    async def _write_metadata(cls, container: Container, user: AuthUser):
+        metadata = ContainerMetadata(user=user)
+        async with aiofiles.open(container.metadata_file, "w") as f:
+            await f.write(metadata.model_dump_json())
 
     @classmethod
-    def _container_name(cls, container: DockerContainer) -> str:
-        return container._container["Names"][0].strip("/")  # type: ignore[reportUnknownMemberType]
+    async def _read_metadata(cls, hostname: str) -> ContainerMetadata | None:
+        path = Container.metadata_file_for_hostname(hostname)
+        if not path.exists():
+            return None  # ignore unassigned container
+
+        async with aiofiles.open(path, "r") as f:
+            metadata = ContainerMetadata.model_validate_json(await f.read())
+        return metadata
 
     @classmethod
     def _network_name(cls):

--- a/src/settings.py
+++ b/src/settings.py
@@ -58,9 +58,9 @@ class Settings(BaseSettings):
         """Only supports GitHub for now."""
         return "github"
 
-    def server_mount_dir(self, server_name: str) -> Path:
-        parent_path = Path(self.HOST_DATA_DIR) / "server_mounts"
-        path = parent_path / server_name
+    @property
+    def server_mount_parent_dir(self) -> Path:
+        path = Path(self.HOST_DATA_DIR) / "server_mounts"
         if not path.exists():
             path.mkdir(parents=True, exist_ok=True)
         return path

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "24.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -710,6 +719,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiodocker" },
+    { name = "aiofiles" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "nanoid" },
@@ -729,6 +739,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiodocker", specifier = ">=0.24.0" },
+    { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "fastmcp", specifier = ">=2.12.2" },
     { name = "nanoid", specifier = ">=2.0.0" },


### PR DESCRIPTION
create a `metadata.json` in the container mounted dir to store user account when assigning a container to a user
that allows to recreate the container for the same user by loading the `metadata.json` file

add a `Container` wrapper class to manage container properties

tested with fresh start, restart mcp-gateway, and verified user states are preserved 